### PR TITLE
Make compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: python
 
 python:
-  - 2.6
-  - 2.7
+  - "2.7"
+  - "3.3"
 
 env:
-  - DJANGO_VERSION=Django==1.3.4
-  - DJANGO_VERSION=Django==1.3.7
+  - DJANGO_VERSION=Django==1.4.2
   - DJANGO_VERSION=Django==1.4.3
+  - DJANGO_VERSION=Django==1.4.4
   - DJANGO_VERSION=Django==1.4.5
   - DJANGO_VERSION=Django==1.5
+  - DJANGO_VERSION=Django==1.5.1
 
 # command to install dependencies
 install:
@@ -19,3 +20,14 @@ install:
 
 script:
   - python runtests.py
+
+matrix:
+  exclude:
+    - python: "3.3"
+      env: DJANGO_VERSION=Django==1.4.2
+    - python: "3.3"
+      env: DJANGO_VERSION=Django==1.4.3
+    - python: "3.3"
+      env: DJANGO_VERSION=Django==1.4.4
+    - python: "3.3"
+      env: DJANGO_VERSION=Django==1.4.5

--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -5,6 +5,7 @@
 # Should be executed with a cron job.
 #
 #---------------------------------------------#
+from django.utils.encoding import python_2_unicode_compatible
 import datetime
 import logging
 import os
@@ -29,6 +30,7 @@ class MailerMessageManager(models.Manager):
             email.send()
 
 
+@python_2_unicode_compatible
 class MailerMessage(models.Model):
     subject = models.CharField(max_length=250, blank=True)
     to_address = models.EmailField(max_length=250)
@@ -42,7 +44,7 @@ class MailerMessage(models.Model):
 
     objects = MailerMessageManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.subject
 
     def add_attachment(self, attachment):
@@ -89,18 +91,19 @@ class MailerMessage(models.Model):
             try:
                 msg.send()
                 self.sent = True
-            except Exception, e:
+            except Exception as e:
                 self.do_not_send = True
                 logger.error('Mail Queue Exception: {0}'.format(e))
 
             self.save()
 
 
+@python_2_unicode_compatible
 class Attachment(models.Model):
     file_attachment = models.FileField(upload_to='mail-queue/attachments', blank=True, null=True)
     email = models.ForeignKey(MailerMessage, blank=True, null=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.file_attachment.name
 
 @receiver(post_save, sender=MailerMessage)

--- a/mailqueue/tests/__init__.py
+++ b/mailqueue/tests/__init__.py
@@ -16,7 +16,7 @@ class MailQueueTestCase(TestCase):
 
     def _setUp_files(self):
         self.small_file = File(open(os.path.join(self.TEST_ROOT, "attachments", "small.txt"), "r"))
-        self.large_file = File(open(os.path.join(self.TEST_ROOT, "attachments", "big.pdf"), "r"))
+        self.large_file = File(open(os.path.join(self.TEST_ROOT, "attachments", "big.pdf"), "rb"))
 
     def tearDown(self):
         setattr(settings, "MAILQUEUE_CELERY", self.MAILQUEUE_CELERY)
@@ -45,8 +45,8 @@ class MailQueueTestCase(TestCase):
         test_message.add_attachment(self.small_file)
         test_message.save()
 
-        self.assertEqual(mail.outbox[0].attachments[0][0], u"small.txt")
-        self.assertEqual(mail.outbox[0].attachments[0][1], "This is a small attachment.\n")
+        self.assertEqual(mail.outbox[0].attachments[0][0], "small.txt")
+        self.assertEqual(mail.outbox[0].attachments[0][1], b"This is a small attachment.\n")
 
     def test_add_large_attachment(self):
         self._setUp_files()


### PR DESCRIPTION
Dropped support for Python 2.6 and Django 1.3, if you require support
for these or lower you will need to use an older version of
django-mail-queue. We currently support the following:
- Python 2.7 with Django >= 1.4
- Python 3.3 with Django >= 1.5
