### PR TITLE
Fix in method send_mail instead of send

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -28,7 +28,7 @@ class MailerMessageManager(models.Manager):
             limit = getattr(settings, 'MAILQUEUE_LIMIT', defaults.MAILQUEUE_LIMIT)
 
         for email in self.filter(sent=False)[:limit]:
-            email.send()
+            email.send_mail()
 
     def clear_sent_messages(self, offset=None):
         """ Deletes sent MailerMessage records """


### PR DESCRIPTION
Fixes the management command `send_queued_messages`. email has not method `send`.
