### PR TITLE
Send mail using celery

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -86,8 +86,8 @@ class MailerMessage(models.Model):
         """
 
         if getattr(settings, 'MAILQUEUE_CELERY', defaults.MAILQUEUE_CELERY):
-            from mailqueue import tasks
-            tasks.send_mail(self.pk)
+            from mailqueue.tasks import send_mail
+            send_mail.delay(self.pk)
         else:
             self._send()
 


### PR DESCRIPTION
Send mail through celery should not call the method directly but use `delay`. Otherwise it does not get send through celery but still directly.
