### PR TITLE
Add retry to celery task

### DIFF
--- a/mailqueue/tasks.py
+++ b/mailqueue/tasks.py
@@ -1,10 +1,14 @@
 from celery.task import task
 from .models import MailerMessage
 
-@task(name="tasks.send_mail")
+@task(name="tasks.send_mail", default_retry_delay=5, max_retries=5)
 def send_mail(pk):
     message = MailerMessage.objects.get(pk=pk)
     message._send()
+    
+    # Retry when message is not sent
+    if not message.sent:
+        send_mail.retry([message.pk,])
 
 @task()
 def clear_sent_messages():


### PR DESCRIPTION
Messages do not always get delivered. Built in a retry when message is not sent.
Max retry count could also be a setting.
