### PR TITLE
Remove warning "deprecated" in url.py

### DIFF
--- a/mailqueue/urls.py
+++ b/mailqueue/urls.py
@@ -1,6 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+from . import views
 
-urlpatterns = patterns('mailqueue.views',
-                       url(r'^clear$', 'clear_sent_messages', name='clear_sent_messages'),
-                       url(r'^$', 'run_mail_job', name='run_mail_job'),
-                       )
+urlpatterns = [
+    url(r'^clear$', views.clear_sent_messages, name='clear_sent_messages'),
+    url(r'^$', views.run_mail_job, name='run_mail_job'),
+]


### PR DESCRIPTION
#### What's this Pull Request do?
Remove warning in urls.py. 
"The old syntax using pattern is deprecated in Django 1.8, and will be removed in Django 1.10."

#### What has been changed?
- [x] Remove patterns from urls.py

#### Any background context you want to provide?
version django=1.9.6
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.

#### Screenshots

#### GitHub issues