### PR TITLE
Bugfix/clean messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 *.pyc
 dist/
 django_mail_queue.egg-info/
-.idea
+.idea/
+.vscode/
 *.iml
 /build
 .vagrant

--- a/mailqueue/management/commands/clear_sent_messages.py
+++ b/mailqueue/management/commands/clear_sent_messages.py
@@ -8,7 +8,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # Positional arguments
-        parser.add_argument('offset', nargs='+', type=int)
+        parser.add_argument('offset', type=int)
 
         # Named (optional) arguments
         parser.add_argument('--offset',


### PR DESCRIPTION
#### What's this Pull Request do?
```
>python manage.py clear_sent_messages 20
    MailerMessage.objects.clear_sent_messages(offset=options['offset'])
  File "\lib\site-packages\mailqueue\models.py", line 35, in clear_sent_messages
    delete_before = timezone.now() - offset
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'list'
```

#### What has been changed?
- [x] Change base type for "offset" argument in command to int (was list)

#### Any background context you want to provide?

#### Screenshots

#### GitHub issues
I don't create any issues and in current issues no see this problem.