### PR TITLE
Fixed filename split on windows

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -70,7 +70,7 @@ class MailerMessage(models.Model):
         if self.pk is None:
             self._save_without_sending()
 
-        original_filename = attachment.file.name.split('/')[-1]
+        original_filename = attachment.file.name.split(os.sep)[-1]
         file_content = ContentFile(attachment.read())
 
         new_attachment = Attachment()

--- a/mailqueue/utils.py
+++ b/mailqueue/utils.py
@@ -1,3 +1,4 @@
+import os
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.utils.crypto import get_random_string
@@ -26,7 +27,7 @@ def get_storage():
 def upload_to(instance, filename):
     # Because filename may also contain path
     # which is unneeded and may be harmful
-    filename = filename.split('/')[-1]
+    filename = filename.split(os.sep)[-1]
     # Because instead of filesystem, email message
     # can have multiple attachments with the same filename
     return '{0}/{1}_{2}'.format(MAILQUEUE_ATTACHMENT_DIR, get_random_string(length=24), filename)


### PR DESCRIPTION
Prevent raising WindowsError because of wrong split of filename on Windows.

#### What has been changed?
- [x] replaced `'/'` with `'os.sep'`


#### GitHub issue

#107 
