### PR TITLE
#110 Ensure that `Attachment.__str__()` always returns a string

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -150,4 +150,4 @@ class Attachment(models.Model):
         verbose_name_plural = _('Attachments')
 
     def __str__(self):
-        return self.original_filename
+        return str(self.original_filename)


### PR DESCRIPTION
#### What's this Pull Request do?
This ensures that the `Attachment.__str__()` method always returns a string.

#### GitHub issues

Issue #110 