### PR TITLE
Add support reply_to parameter(from Django 1.8)

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -112,7 +112,8 @@ class MailerMessage(models.Model):
             msg = EmailMultiAlternatives(subject, text_content, from_email)
 
             if self.reply_to:
-                msg.extra_headers.update({"reply-to": self.reply_to})
+                msg.reply_to = [email.strip() for email in self.reply_to.split(',')
+                                if email.strip()]
 
             if self.html_content:
                 html_content = self.html_content


### PR DESCRIPTION
#### What's this Pull Request do?
Fix issue with [empty reply_to.](https://github.com/dstegelman/django-mail-queue/issues/113)

#### What has been changed?
- [x] Changed adding reply_to to email.

#### Any background context you want to provide?
From Django 1.8, EmailMessage and EmailMultiAlternatives now support the reply_to parameter.
[Release notes](https://docs.djangoproject.com/en/2.1/releases/1.8/#email)

So that, if you need to add reply_to, you should use reply_to field of EmailMultiAlternatives when you send email.

#### GitHub issues
https://github.com/dstegelman/django-mail-queue/issues/113